### PR TITLE
Add support for parsing using the Apache Commons CSVParser

### DIFF
--- a/dblp-formatter/pom.xml
+++ b/dblp-formatter/pom.xml
@@ -89,6 +89,11 @@ under the License.
             <artifactId>argparse4j</artifactId>
             <version>0.7.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.2</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/dblp-formatter/src/main/java/de/bigprak/transform/csv/CSVRecordToTupleMap.java
+++ b/dblp-formatter/src/main/java/de/bigprak/transform/csv/CSVRecordToTupleMap.java
@@ -1,0 +1,71 @@
+package de.bigprak.transform.csv;
+
+import java.lang.reflect.Constructor;
+
+import org.apache.commons.csv.CSVRecord;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.tuple.Tuple;
+
+/**
+ * Extract certain columns from the {@link CSVRecord} and store them in a {@link Tuple}.
+ *
+ * @param <T> One of {@link Tuple1}, {@link Tuple2}, ...
+ */
+public class CSVRecordToTupleMap<T extends Tuple> implements MapFunction<CSVRecord, T> {
+    private static final long serialVersionUID = 1L;
+
+    private int[] indices;
+    private Class<?>[] types;
+
+    /**
+     * Specify the columns to extract.
+     *
+     * All types must have an one-argument constructor that takes a {@link String} and
+     * match the generic T when put into a Tuple of the correct size.
+     *
+     * Example:
+     * <pre><code>
+     * // assume T = Tuple3&lt;Long, String, Boolean&gt;
+     * csv = "Peter,22,1456076785,true,Hallo World";
+     * indices = {2, 0, 3};
+     * types = {Long.class, String.class, Boolean.class};
+     * </code></pre>
+     *
+     * @param indices Select which columns to extract (0-based)
+     * @param types Specify the type of each column
+     * @throws IllegalArgumentException When indices and types differ in length
+     */
+    public CSVRecordToTupleMap(int[] indices, Class<?>[] types) {
+        if(indices.length != types.length) {
+            throw new IllegalArgumentException("indices and types have to be of same length");
+        }
+
+        this.indices = indices;
+        this.types = types;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T map(CSVRecord record) throws Exception {
+        Tuple tuple = Tuple.getTupleClass(indices.length).newInstance();
+
+        for(int i = 0; i < indices.length; ++i) {
+            if(indices[i] >= record.size()) {
+                throw new RuntimeException("Requested column " + indices[i] + " but record only has " + record.size() + "columns");
+            }
+
+            Object value = null;
+
+            try {
+                Constructor<?> constructor = types[i].getConstructor(String.class);
+                value = constructor.newInstance(record.get(indices[i]));
+            } catch(Exception e) {
+                throw new RuntimeException("Could not convert column " + indices[i] + " to type " + types[i].getName(), e);
+            }
+
+            tuple.setField(value, i);
+        }
+
+        return (T) tuple;
+    }
+}

--- a/dblp-formatter/src/main/java/de/bigprak/transform/csv/CommonsCSVInputFormat.java
+++ b/dblp-formatter/src/main/java/de/bigprak/transform/csv/CommonsCSVInputFormat.java
@@ -1,0 +1,54 @@
+package de.bigprak.transform.csv;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.flink.api.common.io.DelimitedInputFormat;
+import org.apache.flink.core.fs.Path;
+
+/**
+ * InputFormat for parsing CSVs
+ *
+ * Parse CSVs using {@link DelimitedInputFormat} and the Apache Commons
+ * {@link CSVParser}, which supports configurable {@link CSVFormat}s.
+ * The record separator is not configurable and always {@code '\n'}
+ * (or alternatively {@code "\r\n"}).
+ */
+public class CommonsCSVInputFormat extends DelimitedInputFormat<CSVRecord> {
+    private static final long serialVersionUID = 1L;
+
+    // this will be serialized and send to all workers
+    private CSVFormat format;
+
+    public CommonsCSVInputFormat(CSVFormat format) {
+        super();
+        this.format = format;
+    }
+    public CommonsCSVInputFormat(Path filePath, CSVFormat format) {
+        super(filePath);
+        this.format = format;
+    }
+
+    @Override
+    public CSVRecord readRecord(CSVRecord reuse, byte[] bytes, int offset, int numBytes) throws IOException {
+        // using streams instead of strings avoids unnecessary copies
+        ByteArrayInputStream stream = new ByteArrayInputStream(bytes, offset, numBytes);
+        InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8);
+
+        // try to parse the record as exactly one line of csv (already splitted by DelimitedInputFormat)
+        try(CSVParser parser = new CSVParser(reader, format)) {
+            Iterator<CSVRecord> it = parser.iterator();
+            if(it.hasNext()) {
+                return it.next();
+            }
+        }
+
+        throw new IOException("Error parsing the following csv line: " + new String(bytes, StandardCharsets.UTF_8));
+    }
+}

--- a/dblp-formatter/src/main/java/de/bigprak/transform/csv/CommonsCSVOutputFormat.java
+++ b/dblp-formatter/src/main/java/de/bigprak/transform/csv/CommonsCSVOutputFormat.java
@@ -1,0 +1,67 @@
+package de.bigprak.transform.csv;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.flink.api.common.io.FileOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.core.fs.Path;
+
+/**
+ * OutputFormat for writing CSVs
+ *
+ * Write CSVs using the Apache Commons {@link CSVPrinter}, which supports
+ * configurable {@link CSVFormat}s.
+ */
+public class CommonsCSVOutputFormat<T extends Tuple> extends FileOutputFormat<T> {
+    private static final long serialVersionUID = 1L;
+
+    // this will be serialized and send to all workers
+    private CSVFormat format;
+
+    // this will NOT be serialized to workers
+    private transient CSVPrinter printer;
+
+    public CommonsCSVOutputFormat(CSVFormat format) {
+        super();
+        this.format = format;
+    }
+
+    public CommonsCSVOutputFormat(Path outputPath, CSVFormat format) {
+        super(outputPath);
+        this.format = format;
+    }
+
+    @Override
+    public void open(int taskNumber, int numTasks) throws IOException {
+        super.open(taskNumber, numTasks);
+
+        Writer out = new OutputStreamWriter(new BufferedOutputStream(this.stream, 4096), StandardCharsets.UTF_8);
+        printer = new CSVPrinter(out, format);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if(printer != null) {
+            printer.close();
+        }
+
+        super.close();
+    }
+
+    @Override
+    public void writeRecord(T tuple) throws IOException {
+        int columns = tuple.getArity();
+
+        for(int i = 0; i < columns; ++i) {
+            printer.print(tuple.getField(i));
+        }
+
+        printer.println();
+    }
+}

--- a/dblp-formatter/src/test/java/de/bigprak/transform/csv/CSVParsingTest.java
+++ b/dblp-formatter/src/test/java/de/bigprak/transform/csv/CSVParsingTest.java
@@ -1,0 +1,61 @@
+package de.bigprak.transform.csv;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.QuoteMode;
+import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+
+public class CSVParsingTest {
+    public static void main(String[] args) throws Exception {
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+        CSVFormat csvFormat = CSVFormat.newFormat(',')
+                .withEscape('\\')
+                .withQuoteMode(QuoteMode.NONE)
+                .withNullString("");
+
+        File in = File.createTempFile("de.bigprak.transform.csv", "CSVParsingTest-in");
+        File out = File.createTempFile("de.bigprak.transform.csv", "CSVParsingTest-out");
+        in.deleteOnExit();
+        out.deleteOnExit();
+        out.delete();
+
+        // Extract (in this order) the id, the first Name and the message;
+        // ignore second name and time
+        String csv = "Peter,Franz,1,Hallo Franz\\, wie geht es dir?,1456076785\n" +
+                     "Franz,Peter,2,Sehr gut\\, danke\\, und dir?,1456076892\n" +
+                     "Peter,Franz,3,Alles in Ordnung!,1456076899";
+        int[] indices = {2,0,3};
+        Class<?>[] types = {Long.class, String.class, String.class};
+
+        FileUtils.writeStringToFile(in, csv, StandardCharsets.UTF_8);
+
+        env.readFile(new CommonsCSVInputFormat(csvFormat), in.getAbsolutePath())
+           .map(new CSVRecordToTupleMap<Tuple3<Long, String, String>>(indices, types))
+           // necessary, because flink cannot deduce return type from generic Mapper
+           .returns("Tuple3<Long, String, String>")
+           .writeAsCsv(out.getAbsolutePath());
+
+        env.setParallelism(1);
+        env.execute();
+
+        String result = FileUtils.readFileToString(out, StandardCharsets.UTF_8);
+
+        // show results
+        System.out.println();
+        System.out.println("Input csv: ");
+        System.out.println(csv);
+
+        System.out.println();
+        System.out.println("Extraction parameters: " + Arrays.toString(indices) + " (" + Arrays.toString(types) + ")");
+
+        System.out.println();
+        System.out.println("Resulting csv: ");
+        System.out.println(result);
+    }
+}

--- a/dblp-formatter/src/test/java/de/bigprak/transform/csv/CSVParsingTest.java
+++ b/dblp-formatter/src/test/java/de/bigprak/transform/csv/CSVParsingTest.java
@@ -15,6 +15,7 @@ public class CSVParsingTest {
         ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
         CSVFormat csvFormat = CSVFormat.newFormat(',')
+                .withRecordSeparator('\n')
                 .withEscape('\\')
                 .withQuoteMode(QuoteMode.NONE)
                 .withNullString("");
@@ -39,7 +40,7 @@ public class CSVParsingTest {
            .map(new CSVRecordToTupleMap<Tuple3<Long, String, String>>(indices, types))
            // necessary, because flink cannot deduce return type from generic Mapper
            .returns("Tuple3<Long, String, String>")
-           .writeAsCsv(out.getAbsolutePath());
+           .write(new CommonsCSVOutputFormat<Tuple3<Long, String, String>>(csvFormat), out.getAbsolutePath());
 
         env.setParallelism(1);
         env.execute();


### PR DESCRIPTION
This PR adds a new `CommonsCSVInputFormat` that can be used to parse CSVs using the Apache Commons `CSVParser`. To convert the resulting `CSVRecord`s to the usual Tuples, the new mapper `CSVRecordToTupleMap` is provided.

See the included integration test for an example of how to use these two new classes.
